### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,7 +21,7 @@ Currently only JPEG is supported through exifr gem.
   xmp.namespaces.each do |namespace_name|
     namespace = xmp.send(namespace_name)
     namespace.attributes.each do |attr|
-      puts "#{namespace_name}.#{attr}: " + namespace.send(attr).inspect
+      puts "#{namespace_name}.#{attr}: " + namespace.public_send(attr).inspect
     end
   end
 


### PR DESCRIPTION
Call `public_send` to inspect the metadata instead of `send` to avoid calling private methods (such as `Object#format`)
