### PR TITLE
Test and fix respond_to_missing?

### DIFF
--- a/lib/xmp/convenience.rb
+++ b/lib/xmp/convenience.rb
@@ -10,7 +10,7 @@ module XMP::Convenience
   end
 
   def respond_to_missing?(method_name, include_private = false)
-    include?(key) or super
+    include?(method_name) or super
   end
 
   def to_h

--- a/spec/xmp_spec.rb
+++ b/spec/xmp_spec.rb
@@ -26,6 +26,14 @@ describe XMP do
       @xmp['photoshop']['SupplementalCategories'].should eq(['Nazwa imprezy'])
     end
 
+    it "should respond to standalone attributes" do
+      @xmp.should respond_to(:dc)
+      @xmp.dc.should respond_to(:title)
+      @xmp.should respond_to(:photoshop)
+      @xmp.photoshop.should respond_to(:SupplementalCategories)
+      @xmp.photoshop.should respond_to(:supplemental_categories)
+    end
+
     it "should return standalone attribute hash" do
       @xmp.Iptc4xmpCore.CreatorContactInfo.should eq({'CiAdrCtry' => 'Germany', 'CiAdrCity' => 'Berlin'})
     end


### PR DESCRIPTION
XMP#respond_to_missing?, i.e. the ability to query attributes with #respond_to?, worked in 0.2 but broke in 1.0. Test and fix.