### PR TITLE
License consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ $ rake spec      # run specs
 ```
 
 ## License
-Ruby's license.
+[Ruby's license.](https://www.ruby-lang.org/en/about/license.txt)
 
 Copyright (c) 2011 Wojciech Piekutowski, AmberBit (<http://amberbit.com>) and contributors.

--- a/xmp.gemspec
+++ b/xmp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = ["wojciech.piekutowski@amberbit.com"]
   s.homepage    = "https://github.com/amberbit/xmp"
   s.summary     = %q{Extensible Metadata Platform (XMP) parser for JPEG, TIFF and raw XML files}
-  s.description = %q{Extensible Metadata Platform (XMP) parser extracts metadata from JPED and TIFF image files. It also supports parsing raw XML files containing XMP.}
+  s.description = %q{Extensible Metadata Platform (XMP) parser extracts metadata from JPEG and TIFF image files. It also supports parsing raw XML files containing XMP.}
   s.licenses    = ["MIT"]
 
   s.files         = `git ls-files`.split("\n")

--- a/xmp.gemspec
+++ b/xmp.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/amberbit/xmp"
   s.summary     = %q{Extensible Metadata Platform (XMP) parser for JPEG, TIFF and raw XML files}
   s.description = %q{Extensible Metadata Platform (XMP) parser extracts metadata from JPEG and TIFF image files. It also supports parsing raw XML files containing XMP.}
-  s.licenses    = ["MIT"]
+  s.licenses    = ["Ruby"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
The README has said for a long time that this software is licensed under the Ruby license, but the gemspec was recently changed to say that this software is licensed under the MIT license. It doesn't matter to me which license xmp uses, but I supposed that it would be good to be consistent.

This PR changes the gemspec to match the README. If the intent was really to change the license to MIT, we could instead change the README to match the gemspec.

Also fixes an unrelated typo in the gemspec.